### PR TITLE
fix: proto compiler call in api build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "negative-impl",
  "portpicker",
  "prost",
+ "prost-build",
  "rand",
  "reqwest",
  "routerify",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -59,3 +59,4 @@ serial_test = "2"
 
 [build-dependencies]
 tonic-build = "0"
+prost-build = "0"

--- a/backend/api/build.rs
+++ b/backend/api/build.rs
@@ -1,8 +1,14 @@
 const PROTO_DIR: &str = "../../proto";
 
 fn main() {
+    let mut config = prost_build::Config::new();
+
+    config.protoc_arg("--experimental_allow_proto3_optional");
+    config.bytes(["."]);
+
     tonic_build::configure()
-        .compile(
+        .compile_with_config(
+            config,
             &[
                 format!("{}/scuffle/events/ingest.proto", PROTO_DIR),
                 format!("{}/scuffle/backend/api.proto", PROTO_DIR),


### PR DESCRIPTION
## Proposed changes

The proto compiler needs the special flag `--experimental_allow_proto3_optional` to compile our `.proto` files. The same code is used in the edge, ingest and transcoder build scripts.

## Types of changes

What types of changes does your code introduce to Scuffle?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/ScuffleTV/scuffle/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules