### PR TITLE
Remove OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,54 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "amq-protocol"
-version = "7.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d40d8b2465c7959dd40cee32ba6ac334b5de57e9fca0cc756759894a4152a5d"
-dependencies = [
- "amq-protocol-tcp",
- "amq-protocol-types",
- "amq-protocol-uri",
- "cookie-factory",
- "nom",
- "serde",
-]
-
-[[package]]
-name = "amq-protocol-tcp"
-version = "7.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb2100adae7da61953a2c3a01935d86caae13329fadce3333f524d6d6ce12e2"
-dependencies = [
- "amq-protocol-uri",
- "tcp-stream",
- "tracing 0.1.40",
-]
-
-[[package]]
-name = "amq-protocol-types"
-version = "7.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156ff13c8a3ced600b4e54ed826a2ae6242b6069d00dd98466827cef07d3daff"
-dependencies = [
- "cookie-factory",
- "nom",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "amq-protocol-uri"
-version = "7.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751bbd7d440576066233e740576f1b31fdc6ab86cfabfbd48c548de77eca73e4"
-dependencies = [
- "amq-protocol-types",
- "percent-encoding",
- "url",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,57 +182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0c4a4f319e45986f347ee47fef8bf5e81c9abc3f6f58dc2391439f30df65f0"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand 2.0.1",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-global-executor-trait"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dd14c5a15affd2abcff50d84efd4009ada28a860f01c14f9d654f3e81b3f75"
-dependencies = [
- "async-global-executor",
- "async-trait",
- "executor-trait",
-]
-
-[[package]]
 name = "async-graphql"
 version = "6.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,39 +263,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite",
- "log",
- "parking",
- "polling",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-nats"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e45b67ea596bb94741ef15ba1d90b72c92bdc07553d8033734cb620a2b39f1c"
+checksum = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -406,8 +278,8 @@ dependencies = [
  "once_cell",
  "rand",
  "regex",
- "ring 0.16.20",
- "rustls",
+ "ring 0.17.5",
+ "rustls 0.21.8",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki",
@@ -422,18 +294,6 @@ dependencies = [
  "tokio-rustls",
  "tracing 0.1.40",
  "url",
-]
-
-[[package]]
-name = "async-reactor-trait"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6012d170ad00de56c9ee354aef2e358359deb1ec504254e0e5a3774771de0e"
-dependencies = [
- "async-io",
- "async-trait",
- "futures-core",
- "reactor-trait",
 ]
 
 [[package]]
@@ -459,12 +319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
-
-[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,12 +339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "attohttpc"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,10 +346,12 @@ checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
 dependencies = [
  "http",
  "log",
- "native-tls",
+ "rustls 0.20.9",
  "serde",
  "serde_json",
  "url",
+ "webpki",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -679,31 +529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c36a4d0d48574b3dd360b4b7d95cc651d2b6557b6402848a27d4b228a473e2a"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "fastrand 2.0.1",
- "futures-io",
- "futures-lite",
- "piper",
- "tracing 0.1.40",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,15 +588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,16 +613,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-targets",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -882,15 +688,6 @@ dependencies = [
  "tracing-subscriber 0.3.0",
  "trust-dns-resolver",
  "ulid",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1181,15 +978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "des"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,12 +1014,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
@@ -1373,15 +1155,6 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -1442,18 +1215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "pin-project",
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -1596,21 +1357,6 @@ name = "futures-io"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1932,6 +1678,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls 0.21.8",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,19 +1701,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -2044,36 +1791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.21",
+ "rustix",
  "windows-sys",
 ]
 
@@ -2138,10 +1855,9 @@ dependencies = [
 [[package]]
 name = "jwt"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+source = "git+https://github.com/ScuffleTV/rust-jwt?branch=troy/fixes#63721aedbe64ce02bf826d04415e8fbea49ae111"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.5",
  "crypto-common",
  "digest",
  "hmac",
@@ -2149,28 +1865,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
-]
-
-[[package]]
-name = "lapin"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3067a1fcfbc3fc46455809c023e69b8f6602463201010f4ae5a3b572adb9dc"
-dependencies = [
- "amq-protocol",
- "async-global-executor-trait",
- "async-reactor-trait",
- "async-trait",
- "executor-trait",
- "flume 0.10.14",
- "futures-core",
- "futures-io",
- "parking_lot",
- "pinky-swear",
- "reactor-trait",
- "serde",
- "tracing 0.1.40",
- "waker-fn",
 ]
 
 [[package]]
@@ -2221,12 +1915,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2405,24 +2093,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "negative-impl"
@@ -2677,29 +2347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "p12"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4873306de53fe82e7e484df31e1e947d61514b6ea2ed6cd7b45d63006fd9224"
-dependencies = [
- "cbc",
- "cipher",
- "des",
- "getrandom",
- "hmac",
- "lazy_static",
- "rc2",
- "sha1",
- "yasna",
-]
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,29 +2506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pinky-swear"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d894b67aa7a4bf295db5e85349078c604edaa6fa5c8721e8eca3c7729a27f2ac"
-dependencies = [
- "doc-comment",
- "flume 0.10.14",
- "parking_lot",
- "tracing 0.1.40",
-]
-
-[[package]]
-name = "piper"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
-dependencies = [
- "atomic-waker",
- "fastrand 2.0.1",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,7 +2556,6 @@ dependencies = [
  "hyper",
  "hyper-tungstenite",
  "jwt",
- "lapin",
  "negative-impl",
  "pb",
  "portpicker",
@@ -3066,22 +2689,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys",
 ]
 
 [[package]]
@@ -3261,15 +2868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rc2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "reactor-trait"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3373,21 +2971,22 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.8",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3395,6 +2994,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.2",
  "winreg",
 ]
 
@@ -3555,20 +3155,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
@@ -3576,8 +3162,20 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.11",
+ "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -3590,18 +3188,6 @@ dependencies = [
  "ring 0.17.5",
  "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls-connector"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060bcc1795b840d0e56d78f3293be5f652aa1611d249b0e63ffe19f4a8c9ae23"
-dependencies = [
- "log",
- "rustls",
- "rustls-native-certs",
- "rustls-webpki",
 ]
 
 [[package]]
@@ -4077,10 +3663,11 @@ dependencies = [
  "indexmap 2.1.0",
  "log",
  "memchr",
- "native-tls",
  "once_cell",
  "paste",
  "percent-encoding",
+ "rustls 0.21.8",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
@@ -4092,6 +3679,7 @@ dependencies = [
  "tracing 0.1.40",
  "url",
  "uuid",
+ "webpki-roots 0.24.0",
 ]
 
 [[package]]
@@ -4226,7 +3814,7 @@ checksum = "d59dc83cf45d89c555a577694534fcd1b55c545a816c816ce51f20bbe56a4f3f"
 dependencies = [
  "atoi",
  "chrono",
- "flume 0.11.0",
+ "flume",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4343,28 +3931,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tcp-stream"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da30af7998f51ee1aa48ab24276fe303a697b004e31ff542b192c088d5630a5"
-dependencies = [
- "cfg-if",
- "native-tls",
- "p12",
- "rustls-connector",
- "rustls-pemfile",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
+ "fastrand",
  "redox_syscall",
- "rustix 0.38.21",
+ "rustix",
  "windows-sys",
 ]
 
@@ -4503,16 +4078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-reactor-trait"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,7 +4108,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.8",
  "tokio",
 ]
 
@@ -4650,7 +4215,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls",
+ "rustls 0.21.8",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
@@ -5176,13 +4741,14 @@ dependencies = [
  "hyper",
  "itertools",
  "jwt",
- "native-tls",
  "nix",
  "openssl",
  "pb",
  "portpicker",
  "prost",
  "routerify",
+ "rustls 0.21.8",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serial_test",
@@ -5191,7 +4757,7 @@ dependencies = [
  "sqlx-postgres",
  "tempfile",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -5225,12 +4791,13 @@ dependencies = [
  "futures-util",
  "hyper",
  "mp4",
- "native-tls",
  "pb",
  "pnet",
  "portpicker",
  "prost",
  "rtmp",
+ "rustls 0.21.8",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serial_test",
@@ -5239,8 +4806,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-executor-trait",
- "tokio-native-tls",
  "tokio-reactor-trait",
+ "tokio-rustls",
  "tokio-stream",
  "tonic",
  "tracing 0.1.40",
@@ -5307,7 +4874,6 @@ dependencies = [
  "futures-util",
  "hyper",
  "mp4",
- "native-tls",
  "nix",
  "pb",
  "portpicker",
@@ -5322,7 +4888,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-native-tls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -5333,12 +4898,6 @@ dependencies = [
  "uuid",
  "video-common",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
@@ -5455,6 +5014,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.5",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5463,7 +5056,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.21",
+ "rustix",
 ]
 
 [[package]]
@@ -5602,12 +5195,6 @@ dependencies = [
  "cfg-if",
  "windows-sys",
 ]
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ members = [
 
 resolver = "2"
 
+[profile.release]
+lto = 'fat'
+
 [profile.wasm]
 lto = 'fat'
 panic = 'abort'
@@ -49,3 +52,6 @@ video-player-types = { path = "video/player_types" }
 tracing = { git = "https://github.com/ScuffleTV/tracing" }
 tracing-subscriber = { git = "https://github.com/ScuffleTV/tracing" }
 tracing-log = { git = "https://github.com/ScuffleTV/tracing" }
+
+[patch.crates-io]
+jwt = { git = "https://github.com/ScuffleTV/rust-jwt", branch = "troy/fixes" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,27 +20,27 @@ default = ["logging", "grpc", "context", "prelude", "signal", "macros", "config"
 
 [dependencies]
 log = { version = "0.4.20", optional = true }
-http = { version = "0.2.9", optional = true }
+http = { version = "0.2.10", optional = true }
 tower = { version = "0.4.13", optional = true }
 config = { workspace = true, optional = true }
-futures = { version = "0.3.28", optional = true }
+futures = { version = "0.3.29", optional = true }
 tracing = { version = "0.2.0", optional = true, git = "https://github.com/tokio-rs/tracing.git" }
 arc-swap = { version = "1.6.0", optional = true }
-tokio-util = { version = "0.7.9", optional = true }
-async-trait = { version = "0.1.73", optional = true }
+tokio-util = { version = "0.7.10", optional = true }
+async-trait = { version = "0.1.74", optional = true }
 tonic = { version = "0.10.2", features = ["tls"], optional = true }
-tokio = { version = "1.32.0", features = ["sync", "rt"], optional = true }
-serde = { version = "1.0.188", features = ["derive"], optional = true }
+tokio = { version = "1.34.0", features = ["sync", "rt"], optional = true }
+serde = { version = "1.0.192", features = ["derive"], optional = true }
 tracing-log = { version = "0.2.0", features = ["env_logger"], optional = true, git = "https://github.com/tokio-rs/tracing.git" }
 once_cell = { version = "1.18.0", optional = true }
-trust-dns-resolver = { version = "0.23.0", features = ["tokio-runtime"], optional = true }
+trust-dns-resolver = { version = "0.23.2", features = ["tokio-runtime"], optional = true }
 tracing-subscriber = { version = "0.3.0", features = ["fmt", "env-filter", "json"], optional = true, git = "https://github.com/tokio-rs/tracing.git" }
-thiserror = { version = "1.0.49", optional = true }
+thiserror = { version = "1.0.50", optional = true }
 fred = { version = "7.0.0", optional = true }
 
 fnv = { version = "1.0.7", optional = true }
-futures-util = { version = "0.3.28", optional = true }
-futures-channel = { version = "0.3.28", optional = true }
+futures-util = { version = "0.3.29", optional = true }
+futures-channel = { version = "0.3.29", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 
 const_format = { version = "0.2.32" }
@@ -48,7 +48,7 @@ const_format = { version = "0.2.32" }
 [dev-dependencies]
 ulid = "1.1.0"
 prost = "0.12.1"
-tempfile = "3.8.0"
+tempfile = "3.8.1"
 portpicker = "0.1.1"
 serial_test = "2.0.0"
 dotenvy = "0.15.7"

--- a/config/config/Cargo.toml
+++ b/config/config/Cargo.toml
@@ -11,23 +11,23 @@ keywords = ["config", "cli", "proc-macro"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.49"
-serde = { version = "1.0.188", features = ["derive", "rc"] }
-tracing = { version = "0.1.37" }
+thiserror = "1.0.50"
+serde = { version = "1.0.192", features = ["derive", "rc"] }
+tracing = { version = "0.1.40" }
 serde_ignored = "0.1.9"
 serde-value = "0.7.0"
 serde_path_to_error = "0.1.14"
 humantime = "2.1.0"
 num-order = "1.2.0"
-uuid = { version = "1.4.1", features = ["serde"] }
+uuid = { version = "1.5.0", features = ["serde"] }
 
 # Parsing files
-serde_json = "1.0.107"
-serde_yaml = "0.9.25"
-toml = "0.8.2"
+serde_json = "1.0.108"
+serde_yaml = "0.9.27"
+toml = "0.8.8"
 
 # CLI
-clap = { version = "4.4.6", features = ["cargo", "string"] }
+clap = { version = "4.4.7", features = ["cargo", "string"] }
 convert_case = "0.6.0"
 
 # Derive macro

--- a/config/config_derive/Cargo.toml
+++ b/config/config_derive/Cargo.toml
@@ -14,6 +14,6 @@ keywords = ["config", "cli", "proc-macro"]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.67"
+proc-macro2 = "1.0.69"
 quote = "1.0.33"
-syn = { version = "2.0.37", features = ["full"] }
+syn = { version = "2.0.39", features = ["full"] }

--- a/platform/api/Cargo.toml
+++ b/platform/api/Cargo.toml
@@ -6,22 +6,22 @@ authors = ["Scuffle <opensource@scuffle.tv>"]
 description = "Scuffle API server"
 
 [dependencies]
-tracing = "0.1.37"
-tokio = { version = "1.32.0", features = ["full"] }
-serde = { version = "1.0.188", features = ["derive"] }
+tracing = "0.1.40"
+tokio = { version = "1.34.0", features = ["full"] }
+serde = { version = "1.0.192", features = ["derive"] }
 hyper = { version = "0.14.27", features = ["full"] }
 common = { workspace = true }
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-native-tls", "json", "chrono", "uuid"] }
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio", "tls-rustls", "json", "chrono", "uuid"] }
 sqlx-postgres = "0.7.2"
 routerify = "3.0.0"
-serde_json = "1.0.107"
-reqwest = { version = "0.11.22", features = ["json"] }
+serde_json = "1.0.108"
+reqwest = { version = "0.11.22", features = ["json", "rustls-tls"], default-features = false}
 chrono = { version = "0.4.31", default-features = false, features = ["serde", "clock"] }
-async-graphql = { version = "6.0.7", features = ["apollo_tracing", "apollo_persisted_queries", "tracing", "string_number"] }
+async-graphql = { version = "6.0.10", features = ["apollo_tracing", "apollo_persisted_queries", "tracing", "string_number"] }
 hyper-tungstenite = "0.11.1"
 async-stream = "0.3.5"
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.29"
+futures-util = "0.3.29"
 arc-swap = "1.6.0"
 jwt = "0.16.0"
 hmac = "0.12.1"
@@ -29,27 +29,26 @@ sha2 = "0.10.8"
 negative-impl  = "0.1.4"
 tonic = { version = "0.10.2", features = ["tls"] }
 prost = "0.12.1"
-uuid = "1.4.1"
-bitmask-enum = "2.2.2"
+uuid = "1.5.0"
+bitmask-enum = "2.2.3"
 argon2 = "0.5.2"
 ulid = { version = "1.1.0", features = ["uuid"] }
 email_address = "0.2.4"
 rand = "0.8.5"
-lapin = { version = "2.3.1", features = ["native-tls"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-async-nats = "0.32.1"
-async-trait = "0.1.73"
+async-nats = "0.33.0"
+async-trait = "0.1.74"
 bytes = "1.5.0"
 
 config = { workspace = true }
 pb = { workspace = true }
 totp-rs = { version = "5.4.0", features = ["qr"] }
-thiserror = "1.0.49"
+thiserror = "1.0.50"
 
 [dev-dependencies]
-tempfile = "3.8.0"
+tempfile = "3.8.1"
 dotenvy = "0.15.7"
-http = "0.2.9"
+http = "0.2.10"
 tokio-tungstenite = "0.20.1"
 portpicker = "0.1.1"
 serial_test = "2.0.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -9,13 +9,13 @@ description = "Scuffle Protobuf definitions for scuffle"
 tonic = "0.10.2"
 prost = "0.12.1"
 ulid = "1.1.0"
-uuid = "1.4.1"
+uuid = "1.5.0"
 
 [build-dependencies]
 tonic-build = "0.10.2"
 prost-build = "0.12.1"
 walkdir = "2.4.0"
-syn = { version = "2.0.37", features = ["full"] }
+syn = { version = "2.0.39", features = ["full"] }
 quote = "1.0.33"
-proc-macro2 = "1.0.67"
+proc-macro2 = "1.0.69"
 prettyplease = "0.2.15"

--- a/video/api/Cargo.toml
+++ b/video/api/Cargo.toml
@@ -6,32 +6,32 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
-tracing = "0.1.37"
+tokio = { version = "1.34.0", features = ["full"] }
+tracing = "0.1.40"
 anyhow = "1.0.75"
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-native-tls", "json", "chrono", "uuid"] }
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio", "tls-rustls", "json", "chrono", "uuid"] }
 sqlx-postgres = "0.7.2"
 tonic = { version = "0.10.2", features = ["tls"] }
 prost = "0.12.1"
-uuid = { version = "1.4.1", features = ["v4"] }
-serde = { version = "1.0.188", features = ["derive"] }
+uuid = { version = "1.5.0", features = ["v4"] }
+serde = { version = "1.0.192", features = ["derive"] }
 chrono = { version = "0.4.31", default-features = false, features = ["serde", "clock"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 async-stream = "0.3.5"
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.29"
+futures-util = "0.3.29"
 bytes = "1.5.0"
-async-graphql = { version = "6.0.7", default-features = false, features = ["dataloader"] }
-async-trait = "0.1.73"
+async-graphql = { version = "6.0.10", default-features = false, features = ["dataloader"] }
+async-trait = "0.1.74"
 jwt = "0.16.0"
 hmac = "0.12.1"
 sha2 = "0.10.8"
 rand = "0.8.5"
-async-nats = "0.32.1"
+async-nats = "0.33.0"
 ulid = "1.1.0"
 hex = "0.4.3"
-base64 = "0.21.4"
-serde_json = "1.0.107"
+base64 = "0.21.5"
+serde_json = "1.0.108"
 
 common = { workspace = true, features = ["default"] }
 config = { workspace = true }

--- a/video/common/Cargo.toml
+++ b/video/common/Cargo.toml
@@ -4,21 +4,21 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
-tracing = "0.1.37"
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-native-tls", "json", "chrono", "uuid"] }
+tokio = { version = "1.34.0", features = ["full"] }
+tracing = "0.1.40"
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio", "tls-rustls", "json", "chrono", "uuid"] }
 sqlx-postgres = "0.7.2"
 prost = "0.12.1"
-uuid = { version = "1.4.1", features = ["v4"] }
+uuid = { version = "1.5.0", features = ["v4"] }
 ulid = { version = "1.1.0", features = ["uuid"] }
-serde = { version = "1.0.188", features = ["derive"] }
+serde = { version = "1.0.192", features = ["derive"] }
 chrono = { version = "0.4.31", default-features = false, features = ["serde", "clock"] }
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.29"
+futures-util = "0.3.29"
 bytes = "1.5.0"
-async-graphql = { version = "6.0.7", default-features = false, features = ["dataloader"] }
-async-trait = "0.1.73"
-async-nats = "0.32.1"
+async-graphql = { version = "6.0.10", default-features = false, features = ["dataloader"] }
+async-trait = "0.1.74"
+async-nats = "0.33.0"
 
 pb = { workspace = true }
 common = { workspace = true }

--- a/video/edge/Cargo.toml
+++ b/video/edge/Cargo.toml
@@ -7,35 +7,36 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-tracing = "0.1.37"
-native-tls = "0.2.11"
-tokio-native-tls = "0.3.1"
-tokio = { version = "1.32.0", features = ["full"] }
-serde = { version = "1.0.188", features = ["derive"] }
+tracing = "0.1.40"
+rustls = "0.21.8"
+rustls-pemfile = "1.0.4"
+tokio-rustls = "0.24.1"
+tokio = { version = "1.34.0", features = ["full"] }
+serde = { version = "1.0.192", features = ["derive"] }
 hyper = { version = "0.14.27", features = ["full"] }
 tonic = { version = "0.10.2", features = ["tls"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 prost = "0.12.1"
 async-stream = "0.3.5"
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.29"
+futures-util = "0.3.29"
 bytes = "1.5.0"
-async-trait = "0.1.73"
+async-trait = "0.1.74"
 url-parse = "1.0.7"
 nix = "0.27.1"
 sha2 = "0.10.8"
-tokio-util = "0.7.9"
+tokio-util = "0.7.10"
 tokio-stream = "0.1.14"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 routerify = "3.0.0"
-uuid = { version = "1.4.1", features = ["v4"] }
+uuid = { version = "1.5.0", features = ["v4"] }
 url = "2.4.1"
-async-nats = "0.32.1"
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-native-tls", "json", "chrono", "uuid"] }
+async-nats = "0.33.0"
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio", "tls-rustls", "json", "chrono", "uuid"] }
 sqlx-postgres = "0.7.2"
 hmac = "0.12.1"
 jwt = { version = "0.16.0", features = ["openssl"] }
-openssl = "0.10.57"
+openssl = "0.10.59"
 ulid = { version = "1.1.0", features = ["uuid", "serde"] }
 itertools = "0.11.0"
 
@@ -49,4 +50,4 @@ video-player-types = { workspace = true }
 dotenvy = "0.15.7"
 portpicker = "0.1.1"
 serial_test = "2.0.0"
-tempfile = "3.8.0"
+tempfile = "3.8.1"

--- a/video/ingest/Cargo.toml
+++ b/video/ingest/Cargo.toml
@@ -7,30 +7,31 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-tracing = "0.1.37"
-native-tls = "0.2.11"
-tokio-native-tls = "0.3.1"
-async-trait = "0.1.73"
-tokio = { version = "1.32.0", features = ["full"] }
-serde = { version = "1.0.188", features = ["derive"] }
+tracing = "0.1.40"
+rustls = "0.21.8"
+rustls-pemfile = "1.0.4"
+tokio-rustls = "0.24.1"
+async-trait = "0.1.74"
+tokio = { version = "1.34.0", features = ["full"] }
+serde = { version = "1.0.192", features = ["derive"] }
 hyper = { version = "0.14.27", features = ["full"] }
 tonic = { version = "0.10.2", features = ["tls"] }
 prost = "0.12.1"
 bytes = "1.5.0"
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.29"
+futures-util = "0.3.29"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
-serde_json = "1.0.107"
-uuid = "1.4.1"
+serde_json = "1.0.108"
+uuid = "1.5.0"
 ulid = { version = "1.1.0", features = ["uuid"] }
 async-stream = "0.3.5"
 pnet = "0.34.0"
-async-nats = "0.32.1"
+async-nats = "0.33.0"
 tokio-executor-trait = "2.1.1"
 tokio-reactor-trait = "1.1.0"
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-native-tls", "json", "chrono", "uuid"] }
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio", "tls-rustls", "json", "chrono", "uuid"] }
 sqlx-postgres = "0.7.2"
-base64 = "0.21.4"
+base64 = "0.21.5"
 tokio-stream = "0.1.14"
 
 common = { workspace = true, features = ["default"] }
@@ -48,4 +49,4 @@ video-common = { workspace = true }
 dotenvy = "0.15.7"
 portpicker = "0.1.1"
 serial_test = "2.0.0"
-tempfile = "3.8.0"
+tempfile = "3.8.1"

--- a/video/ingest/src/ingest/mod.rs
+++ b/video/ingest/src/ingest/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use common::prelude::FutureTimeout;
-use std::{sync::Arc, time::Duration};
+use std::{io, sync::Arc, time::Duration};
 use tokio::{net::TcpSocket, select};
 
 use crate::global::GlobalState;
@@ -28,9 +28,22 @@ pub async fn run(global: Arc<GlobalState>) -> Result<()> {
         let cert = std::fs::read(&tls.cert).expect("failed to read rtmp cert");
         let key = std::fs::read(&tls.key).expect("failed to read rtmp key");
 
-        Some(Arc::new(tokio_native_tls::TlsAcceptor::from(
-            native_tls::TlsAcceptor::new(native_tls::Identity::from_pkcs8(&cert, &key)?)?,
-        )))
+        let key = rustls::PrivateKey(
+            rustls_pemfile::pkcs8_private_keys(&mut io::BufReader::new(io::Cursor::new(key)))?
+                .remove(0),
+        );
+
+        let certs = rustls_pemfile::certs(&mut io::BufReader::new(io::Cursor::new(cert)))?
+            .into_iter()
+            .map(rustls::Certificate)
+            .collect();
+
+        Some(Arc::new(tokio_rustls::TlsAcceptor::from(Arc::new(
+            rustls::ServerConfig::builder()
+                .with_safe_defaults()
+                .with_no_client_auth()
+                .with_single_cert(certs, key)?,
+        ))))
     } else {
         None
     };

--- a/video/ingest/src/tests/global.rs
+++ b/video/ingest/src/tests/global.rs
@@ -15,7 +15,7 @@ pub async fn mock_global_state(mut config: AppConfig) -> (Arc<GlobalState>, Hand
     logging::init(&config.logging.level, config.logging.mode)
         .expect("failed to initialize logging");
 
-    config.database.uri = std::env::var("DATABASE_URI").expect("DATABASE_URL must be set");
+    config.database.uri = std::env::var("VIDEO_DATABASE_URL").expect("DATABASE_URL must be set");
     config.nats.servers = vec![std::env::var("NATS_ADDR").expect("NATS_URL must be set")];
 
     let global = Arc::new(GlobalState::new(ctx, config).await.unwrap());

--- a/video/lib/aac/Cargo.toml
+++ b/video/lib/aac/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.5.0"
-byteorder = "1.4.3"
-num-traits = "0.2.16"
-num-derive = "0.4.0"
+byteorder = "1.5.0"
+num-traits = "0.2.17"
+num-derive = "0.4.1"
 bytesio = { workspace = true }

--- a/video/lib/amf0/Cargo.toml
+++ b/video/lib/amf0/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.5.0"
-byteorder = "1.4.3"
-num-traits = "0.2.16"
-num-derive = "0.4.0"
+byteorder = "1.5.0"
+num-traits = "0.2.17"
+num-derive = "0.4.1"
 bytesio = { workspace = true }

--- a/video/lib/av1/Cargo.toml
+++ b/video/lib/av1/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.5.0"
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytesio = { workspace = true }

--- a/video/lib/bytesio/Cargo.toml
+++ b/video/lib/bytesio/Cargo.toml
@@ -8,14 +8,14 @@ tokio = ["dep:tokio-util", "dep:tokio-stream", "dep:tokio", "dep:futures", "dep:
 default = ["tokio"]
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytes = "1.5.0"
 
-futures = { version = "0.3.28", optional = true }
-tokio-util = { version = "0.7.9", features = ["codec"], optional = true  }
+futures = { version = "0.3.29", optional = true }
+tokio-util = { version = "0.7.10", features = ["codec"], optional = true  }
 tokio-stream = { version = "0.1.14", optional = true  }
-tokio = { version = "1.32.0", optional = true  }
+tokio = { version = "1.34.0", optional = true  }
 common = { workspace = true, default-features = false, features = ["prelude"], optional = true  }
 
 [dev-dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.34.0", features = ["full"] }

--- a/video/lib/flv/Cargo.toml
+++ b/video/lib/flv/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytes = "1.5.0"
-num-traits = "0.2.16"
-num-derive = "0.4.0"
+num-traits = "0.2.17"
+num-derive = "0.4.1"
 
 bytesio = { workspace = true }
 av1 = { workspace = true }

--- a/video/lib/h264/Cargo.toml
+++ b/video/lib/h264/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.5.0"
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytesio = { workspace = true }
 exp_golomb = { workspace = true }

--- a/video/lib/h265/Cargo.toml
+++ b/video/lib/h265/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.5.0"
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytesio = { workspace = true }
 exp_golomb = { workspace = true }

--- a/video/lib/mp4/Cargo.toml
+++ b/video/lib/mp4/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytes = "1.5.0"
 fixed = "1.24.0"
 casey = "0.4.0"
@@ -17,5 +17,5 @@ av1 = { workspace = true }
 aac = { workspace = true }
 
 [dev-dependencies]
-serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde = { version = "1.0.192", features = ["derive"] }
+serde_json = "1.0.108"

--- a/video/lib/rtmp/Cargo.toml
+++ b/video/lib/rtmp/Cargo.toml
@@ -4,19 +4,19 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytes = "1.5.0"
 rand = "0.8.5"
 hmac = "0.12.1"
 sha2 = "0.10.8"
-uuid = { version = "1.4.1", features = ["v4"] }
+uuid = { version = "1.5.0", features = ["v4"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
-num-traits = "0.2.16"
-num-derive = "0.4.0"
-tokio = "1.32.0"
-futures = "0.3.28"
-async-trait = "0.1.73"
-tracing = "0.1.37"
+num-traits = "0.2.17"
+num-derive = "0.4.1"
+tokio = "1.34.0"
+futures = "0.3.29"
+async-trait = "0.1.74"
+tracing = "0.1.40"
 
 bytesio = { workspace = true, features = ["default"] }
 flv = { workspace = true }
@@ -24,6 +24,6 @@ h264 = { workspace = true }
 amf0 = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
-serde_json = "1.0.107"
+tokio = { version = "1.34.0", features = ["full"] }
+serde_json = "1.0.108"
 common = { workspace = true }

--- a/video/lib/transmuxer/Cargo.toml
+++ b/video/lib/transmuxer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 bytes = "1.5.0"
 
 bytesio = { workspace = true }
@@ -17,5 +17,5 @@ flv = { workspace = true }
 mp4 = { workspace = true }
 
 [dev-dependencies]
-serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde = { version = "1.0.192", features = ["derive"] }
+serde_json = "1.0.108"

--- a/video/player/Cargo.toml
+++ b/video/player/Cargo.toml
@@ -13,21 +13,21 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4.37"
+wasm-bindgen = "0.2.88"
+wasm-bindgen-futures = "0.4.38"
 console_error_panic_hook = "0.1.7"
-tokio = { version = "1.32.0", features = ["sync", "macros"], default-features = false }
-tracing = { version = "0.1.37", default-features = false, features = ["attributes", "std"]}
+tokio = { version = "1.34.0", features = ["sync", "macros"], default-features = false }
+tracing = { version = "0.1.40", default-features = false, features = ["attributes", "std"]}
 tracing-subscriber = { version = "0.3.17", features = ["registry"], default-features = false }
-tracing-core = { version = "0.1.31", default-features = false }
-serde = { version = "1.0.188", features = ["derive"] }
-serde-wasm-bindgen = "0.6.0"
+tracing-core = { version = "0.1.32", default-features = false }
+serde = { version = "1.0.192", features = ["derive"] }
+serde-wasm-bindgen = "0.6.1"
 tsify = { git = "https://github.com/ScuffleTV/tsify.git", branch = "sisou/comments" }
-js-sys = "0.3.64"
+js-sys = "0.3.65"
 ulid = { version = "1.1.0", default-features = false }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 url = { version = "2.4.1", features = ["serde"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 bytes = "1.5.0"
 serde_path_to_error = "0.1.14"
 
@@ -37,7 +37,7 @@ h264 = { workspace = true }
 bytesio = { workspace = true, default-features = false }
 
 [dependencies.web-sys]
-version = "0.3.64"
+version = "0.3.65"
 features = [
     "console",
     "Window",

--- a/video/player_types/Cargo.toml
+++ b/video/player_types/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.188", features = ["derive"] }
+serde = { version = "1.0.192", features = ["derive"] }
 ulid = { version = "1.1.0", default-features = false }
 url = { version = "2.4.1", default-features = false, features = ["serde"] }

--- a/video/transcoder/Cargo.toml
+++ b/video/transcoder/Cargo.toml
@@ -7,32 +7,30 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-tracing = "0.1.37"
-native-tls = "0.2.11"
-tokio-native-tls = "0.3.1"
-tokio = { version = "1.32.0", features = ["full"] }
-serde = { version = "1.0.188", features = ["derive"] }
+tracing = "0.1.40"
+tokio = { version = "1.34.0", features = ["full"] }
+serde = { version = "1.0.192", features = ["derive"] }
 hyper = { version = "0.14.27", features = ["full"] }
 tonic = { version = "0.10.2", features = ["tls"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 prost = "0.12.1"
 async-stream = "0.3.5"
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.29"
+futures-util = "0.3.29"
 bytes = "1.5.0"
-async-trait = "0.1.73"
+async-trait = "0.1.74"
 url-parse = "1.0.7"
 nix = { version = "0.27.1", features = ["fs", "user"] }
 sha2 = "0.10.8"
-tokio-util = { version = "0.7.9", features = ["compat"] }
+tokio-util = { version = "0.7.10", features = ["compat"] }
 tokio-stream = "0.1.14"
 ulid = { version = "1.1.0", features = ["uuid"] }
-uuid = { version = "1.4.1", features = ["serde", "v4"] }
-async-nats = "0.32.1"
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-native-tls", "json", "chrono", "uuid"] }
+uuid = { version = "1.5.0", features = ["serde", "v4"] }
+async-nats = "0.33.0"
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio", "tls-rustls", "json", "chrono", "uuid"] }
 sqlx-postgres = "0.7.2"
-thiserror = "1.0.49"
-rust-s3 = "0.33.0"
+thiserror = "1.0.50"
+rust-s3 = { version = "0.33.0", default-features = false, features = ["tags", "tokio-rustls-tls", "fail-on-err"] }
 
 aac = { workspace = true }
 mp4 = { workspace = true }
@@ -46,7 +44,7 @@ video-common = { workspace = true }
 dotenvy = "0.15.7"
 portpicker = "0.1.1"
 serial_test = "2.0.0"
-tempfile = "3.8.0"
-serde_json = "1.0.107"
+tempfile = "3.8.1"
+serde_json = "1.0.108"
 transmuxer = { workspace = true }
 flv = { workspace = true }


### PR DESCRIPTION
This commit switches to using rustls over openssl. Unfortunately, rust-jwt needs openssl for the PKeyVerify impl, so we also forked their repo to add support for openssl-vendored which means that it will be staticly linked rather than a system-dep. This feature is only used by video-edge and lto-fat purges it from all other binaries.

## Proposed changes

Describe the big picture of what you want to change here, to help the maintainers understand why we should accept this pull request. Be sure to link to the issue if it fixes a bug or resolves a feature request.

## Types of changes

What types of changes does your code introduce to Scuffle?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/ScuffleTV/scuffle/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, you may want to start the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.
